### PR TITLE
fix(SLK-125528): preserve resolved PR comments across commits (github)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure git url
         run: |
           git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf https://github.com/argonsecurity/
-          git config --global url.https://${{ secrets.AQUASEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
+          git config --global url.https://${{ secrets.AQUA_SEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         env:
@@ -34,4 +34,4 @@ jobs:
         if: always()
         run: |
           git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf
-          git config --global --unset url.https://${{ secrets.AQUASEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf
+          git config --global --unset url.https://${{ secrets.AQUA_SEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,14 +22,16 @@ jobs:
           go-version: "1.22"
       - name: Configure git url
         run: |
-          git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/.insteadOf https://github.com/
+          git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf https://github.com/argonsecurity/
+          git config --global url.https://${{ secrets.AQUASEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         env:
-          GOPRIVATE: github.com/argonsecurity/*
+          GOPRIVATE: github.com/argonsecurity/*, github.com/aquasec-com/*
         with:
           args: --timeout=5m
       - name: Remove git url
         if: always()
         run: |
-          git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/.insteadOf
+          git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf
+          git config --global --unset url.https://${{ secrets.AQUASEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,17 +16,20 @@ jobs:
     name: lint
     runs-on: arc-runner-set
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
       - name: Configure git url
         run: |
           git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/.insteadOf https://github.com/
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v9
         env:
           GOPRIVATE: github.com/argonsecurity/*
         with:
           args: --timeout=5m
-        
       - name: Remove git url
+        if: always()
         run: |
-          git config --global url.https://github.com/.insteadOf https://${{ secrets.ARGON_GH_TOKEN }}@github.com/
+          git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/.insteadOf

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set
     steps:
       - uses: actions/checkout@v3
       - name: Configure git url

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure git url
         run: |
           git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf https://github.com/argonsecurity/
-          git config --global url.https://${{ secrets.AQUA_SEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
+          git config --global url.https://${{ secrets.AQUASEC_COM_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         env:
@@ -34,4 +34,4 @@ jobs:
         if: always()
         run: |
           git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf
-          git config --global --unset url.https://${{ secrets.AQUA_SEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf
+          git config --global --unset url.https://${{ secrets.AQUASEC_COM_GH_TOKEN }}@github.com/aquasec-com/.insteadOf

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: testing PR build
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,24 +9,31 @@ jobs:
     runs-on: arc-runner-set
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
           stable: "false"
           go-version: "1.18"
-      - run: go version
+
+      - name: Go version check
+        run: go version
 
       - name: Configure git url
         run: |
           git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf https://github.com/argonsecurity/
           git config --global url.https://${{ secrets.AQUASEC_COM_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
+
       - name: Run tests
         env:
           GOPRIVATE: github.com/argonsecurity/*, github.com/aquasec-com/*
+          CGO_ENABLED: 0  # Disables CGO to bypass the requirement for gcc
         run: go test -v ./...
+
       - name: Remove git url
         if: always()
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,12 +21,14 @@ jobs:
 
       - name: Configure git url
         run: |
-          git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/.insteadOf https://github.com/
+          git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf https://github.com/argonsecurity/
+          git config --global url.https://${{ secrets.AQUASEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
       - name: Run tests
         env:
-          GOPRIVATE: github.com/argonsecurity/*
+          GOPRIVATE: github.com/argonsecurity/*, github.com/aquasec-com/*
         run: go test -v ./...
       - name: Remove git url
         if: always()
         run: |
-          git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/.insteadOf
+          git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf
+          git config --global --unset url.https://${{ secrets.AQUASEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Run tests
         env:
           GOPRIVATE: github.com/argonsecurity/*
-        run: make test
+        run: go test -v ./...
       - name: Remove git url
+        if: always()
         run: |
-          git config --global url.https://github.com/.insteadOf https://${{ secrets.ARGON_GH_TOKEN }}@github.com/
+          git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/.insteadOf

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Configure git url
         run: |
           git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf https://github.com/argonsecurity/
-          git config --global url.https://${{ secrets.AQUA_SEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
+          git config --global url.https://${{ secrets.AQUASEC_COM_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
       - name: Run tests
         env:
           GOPRIVATE: github.com/argonsecurity/*, github.com/aquasec-com/*
@@ -31,4 +31,4 @@ jobs:
         if: always()
         run: |
           git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf
-          git config --global --unset url.https://${{ secrets.AQUA_SEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf
+          git config --global --unset url.https://${{ secrets.AQUASEC_COM_GH_TOKEN }}@github.com/aquasec-com/.insteadOf

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Configure git url
         run: |
           git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf https://github.com/argonsecurity/
-          git config --global url.https://${{ secrets.AQUASEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
+          git config --global url.https://${{ secrets.AQUA_SEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
       - name: Run tests
         env:
           GOPRIVATE: github.com/argonsecurity/*, github.com/aquasec-com/*
@@ -31,4 +31,4 @@ jobs:
         if: always()
         run: |
           git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf
-          git config --global --unset url.https://${{ secrets.AQUASEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf
+          git config --global --unset url.https://${{ secrets.AQUA_SEC_GH_TOKEN }}@github.com/aquasec-com/.insteadOf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: releasing go-git-pr-commenter
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-set
 
     steps:
       - uses: actions/checkout@v3

--- a/pkg/commenter/azure/azure.go
+++ b/pkg/commenter/azure/azure.go
@@ -165,7 +165,7 @@ func (c *Azure) RemovePreviousAquaComments(msg string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	commentsResponse := ThreadsResponse{}
 	err = json.Unmarshal(body, &commentsResponse)

--- a/pkg/commenter/bitbucket-server/bitbucket-server.go
+++ b/pkg/commenter/bitbucket-server/bitbucket-server.go
@@ -152,7 +152,7 @@ func (c *BitbucketServer) getIdsToRemove(commentsToRemove []Comment, msg string,
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	activitiesResponse := ActivitiesResponse{}
 	err = json.Unmarshal(body, &activitiesResponse)

--- a/pkg/commenter/bitbucket/bitbucket.go
+++ b/pkg/commenter/bitbucket/bitbucket.go
@@ -130,7 +130,7 @@ func (c *Bitbucket) getIdsToRemove(commentIdsToRemove []int, msg string, url str
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	commentsResponse := CommentsResponse{}
 	err = json.Unmarshal(body, &commentsResponse)

--- a/pkg/commenter/commenter.go
+++ b/pkg/commenter/commenter.go
@@ -10,3 +10,20 @@ type Repository interface {
 }
 
 var FIRST_AVAILABLE_LINE = -1
+
+// Finding is one logical scanner result. Body must already contain both the
+// Aqua marker and the fingerprint sentinel (see EmbedFingerprint), so that
+// reconciliation can identify and match it across runs.
+type Finding struct {
+	Path        string
+	StartLine   int
+	EndLine     int
+	Body        string
+	Fingerprint string
+}
+
+// Reconciler is an optional capability detected via type assertion; providers
+// that don't implement it fall back to the legacy delete-all + repost path.
+type Reconciler interface {
+	ReconcileAquaComments(marker string, current []Finding) error
+}

--- a/pkg/commenter/github/fingerprint.go
+++ b/pkg/commenter/github/fingerprint.go
@@ -1,0 +1,32 @@
+package github
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	fingerprintPrefix = "<!-- aqua-fingerprint:"
+	fingerprintSuffix = "-->"
+)
+
+// HTML comment so it stays invisible in every Markdown renderer GitHub uses.
+var fingerprintRe = regexp.MustCompile(`<!--\s*aqua-fingerprint:\s*([0-9a-fA-F]+)\s*-->`)
+
+func EmbedFingerprint(body, fp string) string {
+	if fp == "" || fingerprintRe.MatchString(body) {
+		return body
+	}
+	if !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	return body + fingerprintPrefix + " " + fp + " " + fingerprintSuffix
+}
+
+func ExtractFingerprint(body string) string {
+	m := fingerprintRe.FindStringSubmatch(body)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.ToLower(m[1])
+}

--- a/pkg/commenter/github/fingerprint_test.go
+++ b/pkg/commenter/github/fingerprint_test.go
@@ -1,0 +1,64 @@
+package github
+
+import "testing"
+
+func TestEmbedFingerprint(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		fp   string
+		want string
+	}{
+		{
+			name: "appends sentinel on its own line",
+			body: "hello",
+			fp:   "deadbeef",
+			want: "hello\n<!-- aqua-fingerprint: deadbeef -->",
+		},
+		{
+			name: "reuses existing trailing newline",
+			body: "hello\n",
+			fp:   "deadbeef",
+			want: "hello\n<!-- aqua-fingerprint: deadbeef -->",
+		},
+		{
+			name: "no-op when fp empty",
+			body: "hello",
+			fp:   "",
+			want: "hello",
+		},
+		{
+			name: "no-op when sentinel already present",
+			body: "hello\n<!-- aqua-fingerprint: cafebabe -->",
+			fp:   "deadbeef",
+			want: "hello\n<!-- aqua-fingerprint: cafebabe -->",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EmbedFingerprint(tc.body, tc.fp)
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractFingerprint(t *testing.T) {
+	tests := []struct {
+		body string
+		want string
+	}{
+		{"<!-- aqua-fingerprint: deadbeef -->", "deadbeef"},
+		{"prefix\n<!--aqua-fingerprint:CAFEBABE-->\nsuffix", "cafebabe"},
+		{"prefix\n<!--   aqua-fingerprint:   abc123   -->\nsuffix", "abc123"},
+		{"no sentinel here", ""},
+		{"<!-- aqua-fingerprint: not_hex_chars -->", ""},
+	}
+	for _, tc := range tests {
+		got := ExtractFingerprint(tc.body)
+		if got != tc.want {
+			t.Errorf("ExtractFingerprint(%q) = %q, want %q", tc.body, got, tc.want)
+		}
+	}
+}

--- a/pkg/commenter/github/github.go
+++ b/pkg/commenter/github/github.go
@@ -20,6 +20,9 @@ type Github struct {
 	Owner            string
 	Repo             string
 	PrNumber         int
+
+	// GraphQLEndpoint is overridable for tests / future GHE support.
+	GraphQLEndpoint string
 }
 
 var (

--- a/pkg/commenter/github/graphql.go
+++ b/pkg/commenter/github/graphql.go
@@ -1,0 +1,154 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Default endpoint for github.com. GHE rewrites this; we only support github.com today.
+const defaultGraphQLEndpoint = "https://api.github.com/graphql"
+
+const reviewThreadsQuery = `
+query($owner: String!, $name: String!, $number: Int!, $threadCursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $threadCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          startLine
+          comments(first: 100) {
+            nodes {
+              databaseId
+              body
+              path
+              line
+              startLine
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
+type gqlReviewComment struct {
+	DatabaseID int64   `json:"databaseId"`
+	Body       string  `json:"body"`
+	Path       string  `json:"path"`
+	Line       *int    `json:"line"`
+	StartLine  *int    `json:"startLine"`
+}
+
+type gqlReviewThread struct {
+	ID         string `json:"id"`
+	IsResolved bool   `json:"isResolved"`
+	IsOutdated bool   `json:"isOutdated"`
+	Path       string `json:"path"`
+	Line       *int   `json:"line"`
+	StartLine  *int   `json:"startLine"`
+	Comments   struct {
+		Nodes []gqlReviewComment `json:"nodes"`
+	} `json:"comments"`
+}
+
+type gqlPageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+type gqlReviewThreadsResponse struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				ReviewThreads struct {
+					PageInfo gqlPageInfo       `json:"pageInfo"`
+					Nodes    []gqlReviewThread `json:"nodes"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// fetchReviewThreads pages through every review thread on the PR and returns them flattened.
+func (c *connector) fetchReviewThreads(ctx context.Context, token, endpoint string) ([]gqlReviewThread, error) {
+	if endpoint == "" {
+		endpoint = defaultGraphQLEndpoint
+	}
+
+	var all []gqlReviewThread
+	cursor := ""
+	for {
+		vars := map[string]interface{}{
+			"owner":  c.owner,
+			"name":   c.repo,
+			"number": c.prNumber,
+		}
+		if cursor != "" {
+			vars["threadCursor"] = cursor
+		} else {
+			vars["threadCursor"] = nil
+		}
+
+		body, err := json.Marshal(map[string]interface{}{
+			"query":     reviewThreadsQuery,
+			"variables": vars,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("graphql request: %w", err)
+		}
+		raw, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode/100 != 2 {
+			return nil, fmt.Errorf("graphql http %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+		}
+
+		var parsed gqlReviewThreadsResponse
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return nil, fmt.Errorf("graphql decode: %w", err)
+		}
+		if len(parsed.Errors) > 0 {
+			msgs := make([]string, 0, len(parsed.Errors))
+			for _, e := range parsed.Errors {
+				msgs = append(msgs, e.Message)
+			}
+			return nil, fmt.Errorf("graphql: %s", strings.Join(msgs, "; "))
+		}
+
+		page := parsed.Data.Repository.PullRequest.ReviewThreads
+		all = append(all, page.Nodes...)
+		if !page.PageInfo.HasNextPage {
+			break
+		}
+		cursor = page.PageInfo.EndCursor
+	}
+	return all, nil
+}

--- a/pkg/commenter/github/reconcile.go
+++ b/pkg/commenter/github/reconcile.go
@@ -1,0 +1,149 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aquasecurity/go-git-pr-commenter/pkg/commenter"
+	gh "github.com/google/go-github/v44/github"
+)
+
+type aquaThread struct {
+	thread      *gqlReviewThread
+	topComment  *gqlReviewComment
+	fingerprint string
+}
+
+func (c *Github) ReconcileAquaComments(marker string, current []commenter.Finding) error {
+	ctx := context.Background()
+	threads, err := c.ghConnector.fetchReviewThreads(ctx, c.Token, c.GraphQLEndpoint)
+	if err != nil {
+		return fmt.Errorf("list review threads: %w", err)
+	}
+
+	aqua := selectAquaThreads(threads, marker)
+	byFP, legacy := indexAquaThreads(aqua)
+
+	handled := make(map[string]bool)
+	legacyUsed := make(map[*aquaThread]bool)
+
+	for _, f := range current {
+		match := matchThread(f, byFP, legacy, legacyUsed)
+		if match != nil {
+			if f.Fingerprint != "" {
+				handled[f.Fingerprint] = true
+			}
+			if match.thread.IsResolved {
+				continue
+			}
+			if err := c.editComment(ctx, match.topComment.DatabaseID, f.Body); err != nil {
+				return fmt.Errorf("edit comment %d: %w", match.topComment.DatabaseID, err)
+			}
+			continue
+		}
+		// No matching thread — fall through to the existing create path so we
+		// inherit checkCommentRelevant, position calculation, and retries.
+		_ = c.WriteMultiLineComment(f.Path, f.Body, f.StartLine, f.EndLine)
+	}
+
+	for fp, a := range byFP {
+		if handled[fp] || a.thread.IsResolved {
+			continue
+		}
+		if err := c.deleteAquaCommentsInThread(ctx, a.thread, marker); err != nil {
+			return err
+		}
+	}
+	for _, a := range legacy {
+		if legacyUsed[a] || a.thread.IsResolved {
+			continue
+		}
+		if err := c.deleteAquaCommentsInThread(ctx, a.thread, marker); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func selectAquaThreads(threads []gqlReviewThread, marker string) []*aquaThread {
+	out := make([]*aquaThread, 0, len(threads))
+	for i := range threads {
+		t := &threads[i]
+		var top *gqlReviewComment
+		for j := range t.Comments.Nodes {
+			if strings.Contains(t.Comments.Nodes[j].Body, marker) {
+				top = &t.Comments.Nodes[j]
+				break
+			}
+		}
+		if top == nil {
+			continue
+		}
+		out = append(out, &aquaThread{
+			thread:      t,
+			topComment:  top,
+			fingerprint: ExtractFingerprint(top.Body),
+		})
+	}
+	return out
+}
+
+func indexAquaThreads(aqua []*aquaThread) (byFP map[string]*aquaThread, legacy []*aquaThread) {
+	byFP = make(map[string]*aquaThread)
+	for _, a := range aqua {
+		if a.fingerprint == "" {
+			legacy = append(legacy, a)
+			continue
+		}
+		// First-seen wins; later duplicates fall through to deletion below.
+		if _, ok := byFP[a.fingerprint]; !ok {
+			byFP[a.fingerprint] = a
+		}
+	}
+	return byFP, legacy
+}
+
+func matchThread(f commenter.Finding, byFP map[string]*aquaThread, legacy []*aquaThread, used map[*aquaThread]bool) *aquaThread {
+	if f.Fingerprint != "" {
+		if a, ok := byFP[f.Fingerprint]; ok {
+			return a
+		}
+	}
+	for _, a := range legacy {
+		if used[a] {
+			continue
+		}
+		if a.thread.Path == f.Path && intPtrEq(a.thread.StartLine, f.StartLine) && intPtrEq(a.thread.Line, f.EndLine) {
+			used[a] = true
+			return a
+		}
+	}
+	return nil
+}
+
+func intPtrEq(p *int, v int) bool {
+	if p == nil {
+		return v == 0
+	}
+	return *p == v
+}
+
+func (c *Github) editComment(ctx context.Context, id int64, body string) error {
+	_, _, err := c.ghConnector.prs.EditComment(ctx, c.Owner, c.Repo, id, &gh.PullRequestComment{Body: &body})
+	return err
+}
+
+// Only deletes comments authored by Aqua (i.e. carrying the marker) so that any
+// developer replies in the thread are preserved.
+func (c *Github) deleteAquaCommentsInThread(ctx context.Context, t *gqlReviewThread, marker string) error {
+	for _, cm := range t.Comments.Nodes {
+		if !strings.Contains(cm.Body, marker) {
+			continue
+		}
+		if _, err := c.ghConnector.prs.DeleteComment(ctx, c.Owner, c.Repo, cm.DatabaseID); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/commenter/github/reconcile_test.go
+++ b/pkg/commenter/github/reconcile_test.go
@@ -33,11 +33,11 @@ type gqlThreadFixture struct {
 // GraphQL API would return.
 func renderGraphQLResponse(threads []gqlThreadFixture) string {
 	type cmt struct {
-		DatabaseID int64   `json:"databaseId"`
-		Body       string  `json:"body"`
-		Path       string  `json:"path"`
-		Line       *int    `json:"line"`
-		StartLine  *int    `json:"startLine"`
+		DatabaseID int64  `json:"databaseId"`
+		Body       string `json:"body"`
+		Path       string `json:"path"`
+		Line       *int   `json:"line"`
+		StartLine  *int   `json:"startLine"`
 	}
 	type thd struct {
 		ID         string `json:"id"`
@@ -80,7 +80,9 @@ func renderGraphQLResponse(threads []gqlThreadFixture) string {
 				Path:       t.path,
 				Line:       &line,
 				StartLine:  &line,
-				Comments:   struct{ Nodes []cmt `json:"nodes"` }{Nodes: nodes},
+				Comments: struct {
+					Nodes []cmt `json:"nodes"`
+				}{Nodes: nodes},
 			},
 		)
 	}
@@ -96,7 +98,8 @@ func newTestGithub(t *testing.T, threads []gqlThreadFixture, commitFiles []*comm
 	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&counts.graphql, 1)
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, renderGraphQLResponse(threads))
+		body := renderGraphQLResponse(threads)
+		_, _ = w.Write([]byte(body))
 	})
 	// PATCH/DELETE on a single review comment.
 	mux.HandleFunc("/repos/owner/repo/pulls/comments/", func(w http.ResponseWriter, r *http.Request) {
@@ -104,7 +107,7 @@ func newTestGithub(t *testing.T, threads []gqlThreadFixture, commitFiles []*comm
 		case http.MethodPatch:
 			atomic.AddInt32(&counts.edit, 1)
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"id":1}`)
+			_, _ = w.Write([]byte(`{"id":1}`))
 		case http.MethodDelete:
 			atomic.AddInt32(&counts.delete, 1)
 			w.WriteHeader(http.StatusNoContent)
@@ -117,7 +120,7 @@ func newTestGithub(t *testing.T, threads []gqlThreadFixture, commitFiles []*comm
 		if r.Method == http.MethodPost {
 			atomic.AddInt32(&counts.create, 1)
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"id":999}`)
+			_, _ = w.Write([]byte(`{"id":999}`))
 			return
 		}
 		t.Errorf("unexpected method %s on %s", r.Method, r.URL.Path)

--- a/pkg/commenter/github/reconcile_test.go
+++ b/pkg/commenter/github/reconcile_test.go
@@ -1,0 +1,323 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aquasecurity/go-git-pr-commenter/pkg/commenter"
+	gh "github.com/google/go-github/v44/github"
+)
+
+const testMarker = "[This comment was created by Aqua Pipeline]"
+
+type apiCounts struct {
+	graphql, edit, delete, create int32
+}
+
+type gqlThreadFixture struct {
+	resolved    bool
+	path        string
+	line        int
+	fingerprint string
+	body        string
+	commentID   int64
+}
+
+// renderGraphQLResponse marshals fixtures into the same shape the real GitHub
+// GraphQL API would return.
+func renderGraphQLResponse(threads []gqlThreadFixture) string {
+	type cmt struct {
+		DatabaseID int64   `json:"databaseId"`
+		Body       string  `json:"body"`
+		Path       string  `json:"path"`
+		Line       *int    `json:"line"`
+		StartLine  *int    `json:"startLine"`
+	}
+	type thd struct {
+		ID         string `json:"id"`
+		IsResolved bool   `json:"isResolved"`
+		IsOutdated bool   `json:"isOutdated"`
+		Path       string `json:"path"`
+		Line       *int   `json:"line"`
+		StartLine  *int   `json:"startLine"`
+		Comments   struct {
+			Nodes []cmt `json:"nodes"`
+		} `json:"comments"`
+	}
+	out := struct {
+		Data struct {
+			Repository struct {
+				PullRequest struct {
+					ReviewThreads struct {
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+						Nodes []thd `json:"nodes"`
+					} `json:"reviewThreads"`
+				} `json:"pullRequest"`
+			} `json:"repository"`
+		} `json:"data"`
+	}{}
+	for _, t := range threads {
+		body := t.body
+		if t.fingerprint != "" && !strings.Contains(body, "aqua-fingerprint") {
+			body = EmbedFingerprint(body, t.fingerprint)
+		}
+		line := t.line
+		nodes := []cmt{{DatabaseID: t.commentID, Body: body, Path: t.path, Line: &line, StartLine: &line}}
+		out.Data.Repository.PullRequest.ReviewThreads.Nodes = append(
+			out.Data.Repository.PullRequest.ReviewThreads.Nodes,
+			thd{
+				ID:         fmt.Sprintf("PRT_%d", t.commentID),
+				IsResolved: t.resolved,
+				Path:       t.path,
+				Line:       &line,
+				StartLine:  &line,
+				Comments:   struct{ Nodes []cmt `json:"nodes"` }{Nodes: nodes},
+			},
+		)
+	}
+	b, _ := json.Marshal(out)
+	return string(b)
+}
+
+func newTestGithub(t *testing.T, threads []gqlThreadFixture, commitFiles []*commitFileInfo) (*Github, *apiCounts, func()) {
+	t.Helper()
+	counts := &apiCounts{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&counts.graphql, 1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, renderGraphQLResponse(threads))
+	})
+	// PATCH/DELETE on a single review comment.
+	mux.HandleFunc("/repos/owner/repo/pulls/comments/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPatch:
+			atomic.AddInt32(&counts.edit, 1)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"id":1}`)
+		case http.MethodDelete:
+			atomic.AddInt32(&counts.delete, 1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected method %s on %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/repos/owner/repo/pulls/42/comments", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			atomic.AddInt32(&counts.create, 1)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"id":999}`)
+			return
+		}
+		t.Errorf("unexpected method %s on %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+
+	ts := httptest.NewServer(mux)
+
+	client := gh.NewClient(nil)
+	base, _ := url.Parse(ts.URL + "/")
+	client.BaseURL = base
+
+	c := &Github{
+		Token:           "x",
+		Owner:           "owner",
+		Repo:            "repo",
+		PrNumber:        42,
+		GraphQLEndpoint: ts.URL + "/graphql",
+		files:           commitFiles,
+		ghConnector: &connector{
+			prs:      client.PullRequests,
+			owner:    "owner",
+			repo:     "repo",
+			prNumber: 42,
+		},
+	}
+	return c, counts, ts.Close
+}
+
+func filesCovering(path string, start, end int) []*commitFileInfo {
+	return []*commitFileInfo{{
+		FileName:   path,
+		sha:        "abc",
+		ChunkLines: []chunkLines{{Start: start, End: end}},
+	}}
+}
+
+func aquaBody(extra string) string {
+	return extra + "\n" + testMarker
+}
+
+func TestReconcile_ResolvedThreadKept_NoApiWrites(t *testing.T) {
+	c, counts, done := newTestGithub(t,
+		[]gqlThreadFixture{{
+			resolved:    true,
+			path:        "a.go",
+			line:        10,
+			commentID:   100,
+			fingerprint: "deadbeef",
+			body:        aquaBody("old finding text"),
+		}},
+		filesCovering("a.go", 1, 100),
+	)
+	defer done()
+
+	err := c.ReconcileAquaComments(testMarker, []commenter.Finding{{
+		Path: "a.go", StartLine: 10, EndLine: 10,
+		Body:        EmbedFingerprint(aquaBody("refreshed finding text"), "deadbeef"),
+		Fingerprint: "deadbeef",
+	}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if counts.edit != 0 || counts.delete != 0 || counts.create != 0 {
+		t.Fatalf("expected zero writes, got edit=%d delete=%d create=%d", counts.edit, counts.delete, counts.create)
+	}
+}
+
+func TestReconcile_UnresolvedSameFinding_EditsInPlace(t *testing.T) {
+	c, counts, done := newTestGithub(t,
+		[]gqlThreadFixture{{
+			resolved:    false,
+			path:        "a.go",
+			line:        10,
+			commentID:   100,
+			fingerprint: "deadbeef",
+			body:        aquaBody("old finding text"),
+		}},
+		filesCovering("a.go", 1, 100),
+	)
+	defer done()
+
+	err := c.ReconcileAquaComments(testMarker, []commenter.Finding{{
+		Path: "a.go", StartLine: 10, EndLine: 10,
+		Body:        EmbedFingerprint(aquaBody("refreshed finding text"), "deadbeef"),
+		Fingerprint: "deadbeef",
+	}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if counts.edit != 1 || counts.delete != 0 || counts.create != 0 {
+		t.Fatalf("expected edit=1, got edit=%d delete=%d create=%d", counts.edit, counts.delete, counts.create)
+	}
+}
+
+func TestReconcile_UnresolvedStaleFinding_Deletes(t *testing.T) {
+	c, counts, done := newTestGithub(t,
+		[]gqlThreadFixture{{
+			resolved:    false,
+			path:        "a.go",
+			line:        10,
+			commentID:   100,
+			fingerprint: "cafebabe",
+			body:        aquaBody("finding gone in latest scan"),
+		}},
+		filesCovering("a.go", 1, 100),
+	)
+	defer done()
+
+	if err := c.ReconcileAquaComments(testMarker, nil); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if counts.delete != 1 || counts.edit != 0 || counts.create != 0 {
+		t.Fatalf("expected delete=1, got edit=%d delete=%d create=%d", counts.edit, counts.delete, counts.create)
+	}
+}
+
+func TestReconcile_ResolvedStaleFinding_Preserved(t *testing.T) {
+	c, counts, done := newTestGithub(t,
+		[]gqlThreadFixture{{
+			resolved:    true,
+			path:        "a.go",
+			line:        10,
+			commentID:   100,
+			fingerprint: "cafebabe",
+			body:        aquaBody("accepted-risk finding gone too"),
+		}},
+		filesCovering("a.go", 1, 100),
+	)
+	defer done()
+
+	if err := c.ReconcileAquaComments(testMarker, nil); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if counts.edit != 0 || counts.delete != 0 || counts.create != 0 {
+		t.Fatalf("expected no writes, got edit=%d delete=%d create=%d", counts.edit, counts.delete, counts.create)
+	}
+}
+
+func TestReconcile_NewFinding_CreatesComment(t *testing.T) {
+	c, counts, done := newTestGithub(t, nil, filesCovering("a.go", 1, 100))
+	defer done()
+
+	err := c.ReconcileAquaComments(testMarker, []commenter.Finding{{
+		Path: "a.go", StartLine: 10, EndLine: 20,
+		Body:        EmbedFingerprint(aquaBody("brand new"), "feedface"),
+		Fingerprint: "feedface",
+	}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if counts.create != 1 || counts.edit != 0 || counts.delete != 0 {
+		t.Fatalf("expected create=1, got edit=%d delete=%d create=%d", counts.edit, counts.delete, counts.create)
+	}
+}
+
+func TestReconcile_LegacyThread_MatchedByPathAndLine(t *testing.T) {
+	c, counts, done := newTestGithub(t,
+		[]gqlThreadFixture{{
+			resolved:    false,
+			path:        "a.go",
+			line:        10,
+			commentID:   100,
+			fingerprint: "", // legacy: no fingerprint embedded
+			body:        aquaBody("old aqua comment from a previous scanner version"),
+		}},
+		filesCovering("a.go", 1, 100),
+	)
+	defer done()
+
+	err := c.ReconcileAquaComments(testMarker, []commenter.Finding{{
+		Path: "a.go", StartLine: 10, EndLine: 10,
+		Body:        EmbedFingerprint(aquaBody("now with fingerprint"), "deadbeef"),
+		Fingerprint: "deadbeef",
+	}})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if counts.edit != 1 || counts.create != 0 || counts.delete != 0 {
+		t.Fatalf("expected edit=1, got edit=%d delete=%d create=%d", counts.edit, counts.delete, counts.create)
+	}
+}
+
+func TestReconcile_NonAquaThread_Ignored(t *testing.T) {
+	c, counts, done := newTestGithub(t,
+		[]gqlThreadFixture{{
+			resolved:  false,
+			path:      "a.go",
+			line:      10,
+			commentID: 100,
+			body:      "human reviewer comment with no aqua marker",
+		}},
+		filesCovering("a.go", 1, 100),
+	)
+	defer done()
+
+	if err := c.ReconcileAquaComments(testMarker, nil); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if counts.delete != 0 || counts.edit != 0 || counts.create != 0 {
+		t.Fatalf("non-aqua thread must not be touched, got edit=%d delete=%d create=%d", counts.edit, counts.delete, counts.create)
+	}
+}

--- a/pkg/commenter/gitlab/gitlab.go
+++ b/pkg/commenter/gitlab/gitlab.go
@@ -233,7 +233,7 @@ func (c *Gitlab) getIdsToRemove(idsToRemove []DiscussionNote, msg, page string) 
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var discussionsResponse []Discussion
 	err = json.Unmarshal(body, &discussionsResponse)


### PR DESCRIPTION
# Description

[JIRA-125528](https://scalock.atlassian.net/browse/SLK-125528)

Add an opt-in Reconciler capability to the commenter package and implement it for github.com. The implementation reads pullRequest.reviewThreads via GraphQL to learn isResolved, matches threads to current findings via an embedded aqua-fingerprint HTML-comment sentinel, and reconciles instead of the existing delete-all + repost-all behaviour:

- resolved threads are left alone, regardless of whether the finding is still present (so "Resolve conversation" persists across commits)
- unresolved threads whose finding is still present are edited in place
- unresolved threads whose finding is gone are deleted
- new findings get a fresh review comment via the existing write path
- only marker-bearing comments are deleted, so developer replies survive

Legacy comments without a fingerprint sentinel fall back to (path, line) matching for one release cycle so the upgrade does not burst-post duplicates.

GHE, GitLab, Azure, Bitbucket are unchanged in this PR. Repository interface and all existing methods are untouched; Reconciler is detected via type assertion so existing callers keep compiling.

## Type of change

- [ ] Chore (README.md update / pipeline update / etc)
- [x] Bug fix **(non-breaking change which fixes an issue)**
- [ ] Vulnerability fix **(non-breaking change without code changes)**
- [x] New feature **(non-breaking change which adds functionality)**
- [ ] Breaking change **(_(major version increased)_ - no backward compatibility)**

## Testing

- [x] Added / Ran automated tests **(unit / integration / e2e)**
- [ ] Manual tests - **local environment**
- [ ] Manual tests - **dev/staging environment**

## Release

- [ ] Documentation update required? **_(Notified PM on required changes)_**
- [ ] **Requires UI / CICD client / scanner alignment?**
- [ ] **Requires infrastructure alignment?**
- [ ] **Requires migration?**
- [ ] **Has Datadog monitoring?**
- [ ] **No new HIGH / CRITICAL vulnerabilities? _(FIPS ready / Updated KNOW_VULNERABILITIES.md)_**

## Links to related PRs / Migration scripts / Documentation

## Screenshots / Video