### PR TITLE
ci(pr): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,9 @@ name: testing for PR
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: testing PR build


### PR DESCRIPTION
The `pr` workflow runs lint / test only. No GitHub API writes, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 hardening pattern. YAML validated locally.