### PR TITLE
fix(SLK-00000): update goreleaser flag for v2 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean # Changed from --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces the deprecated `--rm-dist` flag with `--clean` to fix the release pipeline crash caused by GoReleaser v2.x updates.

# Description

[JIRA-XXXX](https://scalock.atlassian.net/browse/SAAS-XXXX)

_Summary of the change in this repository_

## Type of change

- [ ] Chore (README.md update / pipeline update / etc)
- [ ] Bug fix **(non-breaking change which fixes an issue)**
- [ ] Vulnerability fix **(non-breaking change without code changes)**
- [ ] New feature **(non-breaking change which adds functionality)**
- [ ] Breaking change **(_(major version increased)_ - no backward compatibility)**

## Testing

- [ ] Added / Ran automated tests **(unit / integration / e2e)**
- [ ] Manual tests - **local environment**
- [ ] Manual tests - **dev/staging environment**

## Release

- [ ] Documentation update required? **_(Notified PM on required changes)_**
- [ ] **Requires UI / CICD client / scanner alignment?**
- [ ] **Requires infrastructure alignment?**
- [ ] **Requires migration?**
- [ ] **Has Datadog monitoring?**
- [ ] **No new HIGH / CRITICAL vulnerabilities? _(FIPS ready / Updated KNOW_VULNERABILITIES.md)_**

## Links to related PRs / Migration scripts / Documentation

## Screenshots / Video