### PR TITLE
fix(SAAS-00000): fix release workflow private module downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,15 +11,22 @@ jobs:
     runs-on: arc-runner-set
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
         with:
           stable: 'false'
           go-version: '1.18'
       - run: go version
+
+      - name: Configure git url
+        run: |
+          git config --global url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf https://github.com/argonsecurity/
+          git config --global url.https://${{ secrets.AQUASEC_COM_GH_TOKEN }}@github.com/aquasec-com/.insteadOf https://github.com/aquasec-com/
 
       - name: Release
         uses: goreleaser/goreleaser-action@v3
@@ -28,3 +35,10 @@ jobs:
           args: release --clean # Changed from --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOPRIVATE: github.com/argonsecurity/*, github.com/aquasec-com/*
+
+      - name: Remove git url
+        if: always()
+        run: |
+          git config --global --unset url.https://${{ secrets.ARGON_GH_TOKEN }}@github.com/argonsecurity/.insteadOf
+          git config --global --unset url.https://${{ secrets.AQUASEC_COM_GH_TOKEN }}@github.com/aquasec-com/.insteadOf


### PR DESCRIPTION
- Adds git insteadOf configurations and GOPRIVATE env to authorize private aquasec-com and argonsecurity dependencies during release hooks.

# Description

[JIRA-XXXX](https://scalock.atlassian.net/browse/SAAS-XXXX)

_Summary of the change in this repository_

## Type of change

- [ ] Chore (README.md update / pipeline update / etc)
- [x] Bug fix **(non-breaking change which fixes an issue)**
- [ ] Vulnerability fix **(non-breaking change without code changes)**
- [ ] New feature **(non-breaking change which adds functionality)**
- [ ] Breaking change **(_(major version increased)_ - no backward compatibility)**

## Testing

- [ ] Added / Ran automated tests **(unit / integration / e2e)**
- [ ] Manual tests - **local environment**
- [ ] Manual tests - **dev/staging environment**

## Release

- [ ] Documentation update required? **_(Notified PM on required changes)_**
- [ ] **Requires UI / CICD client / scanner alignment?**
- [ ] **Requires infrastructure alignment?**
- [ ] **Requires migration?**
- [ ] **Has Datadog monitoring?**
- [ ] **No new HIGH / CRITICAL vulnerabilities? _(FIPS ready / Updated KNOW_VULNERABILITIES.md)_**

## Links to related PRs / Migration scripts / Documentation

## Screenshots / Video